### PR TITLE
Support rustls over native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,10 @@ license = "Apache-2.0"
 
 # Make feature flags for postgres
 [features]
-default = ["postgres"]
+default = ["postgres", "native-tls"]
 postgres = ["sqlx/postgres"]
+native-tls = ["sqlx/runtime-tokio-native-tls"]
+rustls = ["sqlx/runtime-tokio-rustls"]
 
 [dependencies]
 async-trait = "0.1.68"
@@ -20,7 +22,7 @@ indicatif = "0.17.3"
 libc = "0.2.144"
 once_cell = "1.17.2"
 prettytable = "0.10.0"
-sqlx = { version = "^0.6.3", features = ["chrono", "runtime-tokio-native-tls"] }
+sqlx = { version = "^0.6.3", features = ["chrono"] }
 tempfile = "3.5.0"
 thiserror = "1.0.40"
 


### PR DESCRIPTION
I tested this in a fresh crate to ensure that `native-tls` did not get picked up as a feature.